### PR TITLE
Update SVG icon fill color to currentColor

### DIFF
--- a/src/shared/components/Icons/Icons.tsx
+++ b/src/shared/components/Icons/Icons.tsx
@@ -843,7 +843,7 @@ export const SvgIcons = {
         fillRule="evenodd"
         clipRule="evenodd"
         d="M4 2H20C21.1 2 22 2.9 22 4V16C22 17.1 21.1 18 20 18H6L2 22V4C2 2.9 2.9 2 4 2ZM5.17 16H20V4H4V17.17L5.17 16Z"
-        fill="#000000"
+        fill="currentColor"
       />
     </svg>
   ),


### PR DESCRIPTION
Change the fill color of the SVG icon to use currentColor, enhancing styling flexibility.