### PR TITLE
chore(ci): cache Playwright browsers + install only Chromium

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,8 +47,18 @@ jobs:
             exit 1
           fi
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Browsers (only Chromium)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
       - name: Run Playwright tests
         run: npx playwright test
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #83

## Summary

Optimizes the Playwright E2E CI pipeline with two changes:

1. **Cache browser binaries** via `actions/cache@v4` — browsers only download when Playwright version changes
2. **Install only Chromium** instead of all browsers — saves ~200 MiB per build

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/playwright.yml` | Add cache step + switch to `chromium` only |

## Test Plan

- [x] Cache key: `${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}`
- [x] Cache miss: installs Chromium with `--with-deps`
- [x] Cache hit: skips install entirely
- [x] E2E tests unchanged — same `npx playwright test` command
