### PR TITLE
fix(layout): move inline theme script into body for proper rendering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,12 +44,12 @@ export default async function RootLayout({
       lang={locale}
       className={`${poppins.variable} ${lato.variable} antialiased`}
     >
-      {/* Inline script to prevent flash of wrong theme */}
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `(function(){try{var t=localStorage.getItem('portfolio-theme');if(!t){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}if(t==='dark')document.documentElement.classList.add('dark')}catch(e){}})();`,
-        }}
-      />
+      <body className="min-h-screen bg-background-main text-text-main font-body">
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('portfolio-theme');if(!t){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}if(t==='dark')document.documentElement.classList.add('dark')}catch(e){}})();`,
+          }}
+        />
       {GTM_ID && isProduction && (
         <Script
           id="gtm-init"
@@ -76,7 +76,6 @@ export default async function RootLayout({
           </Script>
         </>
       )}
-      <body className="min-h-screen bg-background-main text-text-main font-body">
         {GTM_ID && isProduction && (
           <noscript
             dangerouslySetInnerHTML={{


### PR DESCRIPTION
This pull request makes a small adjustment to the `RootLayout` component in `src/app/layout.tsx` by moving the `<body>` tag up in the component tree. This change ensures that the `<body>` element properly wraps the intended content and maintains the correct structure for scripts and other elements. 

- Moved the `<body>` tag to wrap the main content earlier in the component, instead of inside the conditional rendering block. This helps maintain proper document structure and may prevent layout or script execution issues. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L47-R47) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L79)