### PR TITLE
feat(blog): PostCard and PostBody components with unit tests

### DIFF
--- a/src/app/components/blog/PostBody.test.tsx
+++ b/src/app/components/blog/PostBody.test.tsx
@@ -1,0 +1,312 @@
+import React from "react";
+import { render, screen } from "@/test/utils";
+import { PostBody } from "./PostBody";
+import "@testing-library/jest-dom";
+
+// Mock @portabletext/react — ESM-only, needs mock in Jest
+jest.mock("@portabletext/react", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const PortableText = ({ value, components }: any) => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    return (
+      <>
+        {(value || []).map((block: any, index: number) => {
+          if (block._type === "block") {
+            const style = block.style || "normal";
+            const blockComponent = components?.block?.[style];
+            const markDefs = block.markDefs || [];
+
+            const renderChildren = () => {
+              return (block.children || []).map((child: any) => {
+                const marks = child.marks || [];
+                let element: React.ReactNode = child.text || "";
+
+                for (const markKey of marks) {
+                  const markDef = markDefs.find((m: any) => m._key === markKey);
+                  if (markDef && markDef._type === "link") {
+                    const linkComponent = components?.marks?.link;
+                    if (linkComponent) {
+                      element = linkComponent({
+                        children: element,
+                        value: markDef,
+                        text: child.text,
+                      });
+                    }
+                  }
+                }
+                return element;
+              });
+            };
+
+            const children = renderChildren();
+            if (blockComponent) {
+              return (
+                <React.Fragment key={index}>
+                  {blockComponent({ children, value: block })}
+                </React.Fragment>
+              );
+            }
+            return <p key={index}>{children}</p>;
+          }
+
+          // Custom types
+          const typeComponent = components?.types?.[block._type];
+          if (typeComponent) {
+            return (
+              <React.Fragment key={index}>
+                {typeComponent({ value: block, children: null })}
+              </React.Fragment>
+            );
+          }
+
+          // Unknown type — return null (graceful fallback)
+          return null;
+        })}
+      </>
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  };
+
+  return { PortableText };
+});
+
+// Mock next/image
+jest.mock("next/image", () => {
+  const MockNextImage = (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt} />
+  );
+  MockNextImage.displayName = "MockNextImage";
+  return MockNextImage;
+});
+
+// Mock @/i18n/navigation Link
+jest.mock("@/i18n/navigation", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockLink = ({ children, ...props }: any) => <a {...props}>{children}</a>;
+  return { Link: MockLink };
+});
+
+// Mock @/sanity/lib/image urlFor
+const createUrlForChain = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    width: jest.fn(() => chain),
+    height: jest.fn(() => chain),
+    auto: jest.fn(() => chain),
+    quality: jest.fn(() => chain),
+    url: jest.fn(
+      () => "https://cdn.sanity.io/images/project/dataset/mock-body-image.jpg"
+    ),
+  };
+  return chain;
+};
+
+jest.mock("@/sanity/lib/image", () => ({
+  urlFor: jest.fn(() => createUrlForChain()),
+}));
+
+describe("PostBody", () => {
+  it("renders h2 heading with slugified anchor id", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "h2",
+        children: [{ _type: "span", text: "Introduction" }],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const heading = screen.getByRole("heading", { level: 2 });
+    expect(heading).toHaveTextContent("Introduction");
+    expect(heading).toHaveAttribute("id", "introduction");
+  });
+
+  it("renders h3 and h4 headings with anchor ids", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "h3",
+        children: [{ _type: "span", text: "Getting Started" }],
+      },
+      {
+        _type: "block",
+        style: "h4",
+        children: [{ _type: "span", text: "Edge Cases" }],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const h3 = screen.getByRole("heading", { level: 3 });
+    expect(h3).toHaveTextContent("Getting Started");
+    expect(h3).toHaveAttribute("id", "getting-started");
+
+    const h4 = screen.getByRole("heading", { level: 4 });
+    expect(h4).toHaveTextContent("Edge Cases");
+    expect(h4).toHaveAttribute("id", "edge-cases");
+  });
+
+  it("renders code block with language class", () => {
+    const blocks = [
+      {
+        _type: "code",
+        language: "typescript",
+        code: "const x = 1;",
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const pre = document.querySelector("pre");
+    expect(pre).toBeInTheDocument();
+    const code = pre?.querySelector("code");
+    expect(code).toBeInTheDocument();
+    expect(code).toHaveClass("language-typescript");
+    expect(code).toHaveTextContent("const x = 1;");
+  });
+
+  it("renders image with urlFor source and alt", () => {
+    const blocks = [
+      {
+        _type: "image",
+        asset: { _ref: "image-body-123" },
+        alt: "Diagram of architecture",
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const img = screen.getByRole("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute(
+      "src",
+      "https://cdn.sanity.io/images/project/dataset/mock-body-image.jpg"
+    );
+    expect(img).toHaveAttribute("alt", "Diagram of architecture");
+  });
+
+  it("renders external link with target=_blank and rel=noopener noreferrer", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "normal",
+        children: [
+          {
+            _type: "span",
+            text: "Click here",
+            marks: ["ext-link"],
+          },
+        ],
+        markDefs: [
+          {
+            _key: "ext-link",
+            _type: "link",
+            href: "https://example.com",
+          },
+        ],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const link = screen.getByText("Click here").closest("a");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders internal link without target=_blank", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "normal",
+        children: [
+          {
+            _type: "span",
+            text: "Read more",
+            marks: ["int-link"],
+          },
+        ],
+        markDefs: [
+          {
+            _key: "int-link",
+            _type: "link",
+            href: "/blog/hello-world",
+          },
+        ],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const link = screen.getByText("Read more").closest("a");
+    expect(link).toHaveAttribute("href", "/blog/hello-world");
+    expect(link).not.toHaveAttribute("target");
+    expect(link).not.toHaveAttribute("rel");
+  });
+
+  it("renders blockquote with styling", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "blockquote",
+        children: [{ _type: "span", text: "Quote text" }],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const blockquote = document.querySelector("blockquote");
+    expect(blockquote).toBeInTheDocument();
+    expect(blockquote).toHaveTextContent("Quote text");
+  });
+
+  it("gracefully handles unknown block type without crashing", () => {
+    const blocks = [
+      {
+        _type: "unknownType",
+        someField: "something",
+      },
+    ];
+    expect(() => render(<PostBody body={blocks} />)).not.toThrow();
+  });
+
+  it("does not render image when asset ref is missing", () => {
+    const blocks = [
+      {
+        _type: "image",
+        alt: "Orphan image",
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders http:// external link with target=_blank", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "normal",
+        children: [
+          {
+            _type: "span",
+            text: "HTTP link",
+            marks: ["http-link"],
+          },
+        ],
+        markDefs: [
+          {
+            _key: "http-link",
+            _type: "link",
+            href: "http://example.com",
+          },
+        ],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    const link = screen.getByText("HTTP link").closest("a");
+    expect(link).toHaveAttribute("href", "http://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders data-testid on root element", () => {
+    const blocks = [
+      {
+        _type: "block",
+        style: "normal",
+        children: [{ _type: "span", text: "Hello" }],
+      },
+    ];
+    render(<PostBody body={blocks} />);
+    expect(screen.getByTestId("post-body")).toBeInTheDocument();
+  });
+});

--- a/src/app/components/blog/PostBody.tsx
+++ b/src/app/components/blog/PostBody.tsx
@@ -1,0 +1,134 @@
+import { PortableText, type PortableTextComponents } from "@portabletext/react";
+import Image from "next/image";
+import { Link } from "@/i18n/navigation";
+import { urlFor } from "@/sanity/lib/image";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/* ── Heading Renderer (h2, h3, h4) ── */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function HeadingRenderer({ children, value }: any) {
+  const style = value?.style || "h2";
+  const text = value?.children
+    ?.map((child: { text?: string }) => child.text || "")
+    .join("") || "";
+  const id = slugify(text);
+  const anchor = (
+    <a
+      href={`#${id}`}
+      className="absolute -left-6 top-0 opacity-0 group-hover:opacity-100 transition-opacity text-primary-brand"
+      aria-hidden="true"
+    >
+      #
+    </a>
+  );
+  const className = "group relative font-heading font-bold text-text-main scroll-mt-20";
+  if (style === "h3") {
+    return <h3 id={id} className={className}>{anchor}{children}</h3>;
+  }
+  if (style === "h4") {
+    return <h4 id={id} className={className}>{anchor}{children}</h4>;
+  }
+  return <h2 id={id} className={className}>{anchor}{children}</h2>;
+}
+
+/* ── Blockquote Renderer ── */
+function BlockquoteRenderer({ children }: { children?: React.ReactNode }) {
+  return (
+    <blockquote className="border-l-4 border-primary-brand pl-4 italic text-text-main/80 my-6">
+      {children}
+    </blockquote>
+  );
+}
+
+/* ── Code Renderer ── */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function CodeRenderer({ value }: any) {
+  return (
+    <pre className="bg-background-main rounded-lg p-4 overflow-x-auto my-6">
+      <code className={`language-${value?.language || "text"}`}>
+        {value?.code || ""}
+      </code>
+    </pre>
+  );
+}
+
+/* ── Image Renderer ── */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ImageRenderer({ value }: any) {
+  if (!value?.asset?._ref) return null;
+  const src = urlFor(value).width(800).auto("format").quality(80).url();
+  return (
+    <div className="my-8">
+      <Image
+        src={src}
+        alt={value.alt || ""}
+        width={800}
+        height={450}
+        className="rounded-lg w-full object-cover"
+      />
+    </div>
+  );
+}
+
+/* ── Link Renderer ── */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function LinkRenderer({ children, value }: any) {
+  const href = value?.href || "";
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className="link-text">
+        {children}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className="link-text">
+      {children}
+    </Link>
+  );
+}
+
+/* ── Normal Paragraph Renderer ── */
+function NormalRenderer({ children }: { children?: React.ReactNode }) {
+  return (
+    <p className="font-body text-text-main leading-relaxed mb-4">{children}</p>
+  );
+}
+
+/* ── Main Component ── */
+interface PostBodyProps {
+  body: unknown[];
+}
+
+export function PostBody({ body }: PostBodyProps) {
+  const components: PortableTextComponents = {
+    block: {
+      h2: HeadingRenderer,
+      h3: HeadingRenderer,
+      h4: HeadingRenderer,
+      blockquote: BlockquoteRenderer,
+      normal: NormalRenderer,
+    },
+    types: {
+      code: CodeRenderer,
+      image: ImageRenderer,
+    },
+    marks: {
+      link: LinkRenderer,
+    },
+  };
+
+  return (
+    <div data-testid="post-body" className="max-w-none">
+      <PortableText value={body} components={components} />
+    </div>
+  );
+}

--- a/src/app/components/blog/PostCard.test.tsx
+++ b/src/app/components/blog/PostCard.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen } from "@/test/utils";
+import { PostCard } from "./PostCard";
+import "@testing-library/jest-dom";
+
+// Mock next/image
+jest.mock("next/image", () => {
+  const MockNextImage = (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt} />
+  );
+  MockNextImage.displayName = "MockNextImage";
+  return MockNextImage;
+});
+
+// Mock @/i18n/navigation Link
+jest.mock("@/i18n/navigation", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MockLink = ({ children, ...props }: any) => <a {...props}>{children}</a>;
+  return { Link: MockLink };
+});
+
+// Mock @/sanity/lib/image urlFor
+const createUrlForChain = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {
+    width: jest.fn(() => chain),
+    height: jest.fn(() => chain),
+    auto: jest.fn(() => chain),
+    quality: jest.fn(() => chain),
+    url: jest.fn(() => "https://cdn.sanity.io/images/project/dataset/mock-image.jpg"),
+  };
+  return chain;
+};
+
+jest.mock("@/sanity/lib/image", () => ({
+  urlFor: jest.fn(() => createUrlForChain()),
+}));
+
+const mockPost = {
+  title: "Getting Started with Next.js",
+  slug: "getting-started-nextjs",
+  description: "A comprehensive guide to building modern web applications with Next.js.",
+  publishedAt: "2026-05-15T10:00:00Z",
+  tags: ["Next.js", "React", "TypeScript"],
+  coverImage: {
+    asset: { _ref: "image-abc123" },
+    alt: "Next.js thumbnail",
+  },
+  locale: "en" as const,
+};
+
+describe("PostCard", () => {
+  it("renders title as link with correct href", () => {
+    render(<PostCard {...mockPost} />);
+    const link = screen.getByRole("link", { name: mockPost.title });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", `/blog/${mockPost.slug}`);
+  });
+
+  it("renders formatted date for the given locale", () => {
+    render(<PostCard {...mockPost} />);
+    const expectedDate = new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(new Date("2026-05-15T10:00:00Z"));
+    expect(screen.getByText(expectedDate)).toBeInTheDocument();
+  });
+
+  it("renders tags as pills", () => {
+    render(<PostCard {...mockPost} />);
+    for (const tag of mockPost.tags!) {
+      expect(screen.getByText(tag)).toBeInTheDocument();
+    }
+  });
+
+  it("renders cover image with urlFor source and alt text", () => {
+    render(<PostCard {...mockPost} />);
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "https://cdn.sanity.io/images/project/dataset/mock-image.jpg");
+    expect(img).toHaveAttribute("alt", "Next.js thumbnail");
+  });
+
+  it("does not render an img element when coverImage is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { coverImage: _, ...postWithoutImage } = mockPost;
+    render(<PostCard {...postWithoutImage} coverImage={null} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("does not render tag container when tags are null", () => {
+    render(<PostCard {...mockPost} tags={null} />);
+    for (const tag of mockPost.tags!) {
+      expect(screen.queryByText(tag)).not.toBeInTheDocument();
+    }
+  });
+
+  it("does not render description when description is null", () => {
+    render(<PostCard {...mockPost} description={null} />);
+    expect(
+      screen.queryByText("A comprehensive guide to building modern web applications with Next.js.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders testid attributes on container", () => {
+    render(<PostCard {...mockPost} />);
+    const container = screen.getByTestId("post-card");
+    expect(container).toBeInTheDocument();
+    const specific = screen.getByTestId(`post-card-${mockPost.slug}`);
+    expect(specific).toBeInTheDocument();
+  });
+});

--- a/src/app/components/blog/PostCard.tsx
+++ b/src/app/components/blog/PostCard.tsx
@@ -1,0 +1,79 @@
+import Image from "next/image";
+import { Link } from "@/i18n/navigation";
+import { urlFor } from "@/sanity/lib/image";
+
+interface PostCardProps {
+  title: string;
+  slug: string;
+  description?: string | null;
+  publishedAt?: string | null;
+  tags?: string[] | null;
+  coverImage?: { asset?: { _ref?: string }; alt?: string } | null;
+  locale: string;
+}
+
+export function PostCard({
+  title,
+  slug,
+  description,
+  publishedAt,
+  tags,
+  coverImage,
+  locale,
+}: PostCardProps) {
+  return (
+    <article
+      data-testid={`post-card`}
+      className="card post-card"
+    >
+      <div data-testid={`post-card-${slug}`}>
+        {coverImage?.asset?._ref && (
+          <div className="relative overflow-hidden rounded-lg mb-4">
+            <Image
+              src={urlFor(coverImage).width(600).height(400).auto("format").quality(80).url()}
+              alt={coverImage.alt ?? title}
+              width={600}
+              height={400}
+              className="w-full object-cover"
+            />
+          </div>
+        )}
+
+        <Link href={`/blog/${slug}`}>
+          <h3 className="text-xl font-heading font-bold text-text-main hover:text-primary-brand transition-colors">
+            {title}
+          </h3>
+        </Link>
+
+        {description && (
+          <p className="mt-2 font-body text-text-main/80 leading-relaxed">
+            {description}
+          </p>
+        )}
+
+        {publishedAt && (
+          <p className="mt-2 text-sm font-body text-text-main/60">
+            {new Intl.DateTimeFormat(locale, {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            }).format(new Date(publishedAt))}
+          </p>
+        )}
+
+        {tags && tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-3">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="px-3 py-1 bg-background-main border border-accent/30 text-text-main text-xs font-body font-medium rounded-full"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary

PostCard y PostBody components para el blog, con 19 tests unitarios en Strict TDD.

PR-2 de 4 para core-blog-ui (stacked-to-main). Sobre PR-1 (#90 mergeado).

### Changes

| File | Change |
|------|--------|
| src/app/components/blog/PostCard.tsx | Created - Server Component |
| src/app/components/blog/PostCard.test.tsx | Created - 8 tests |
| src/app/components/blog/PostBody.tsx | Created - PortableText with 6 renderers |
| src/app/components/blog/PostBody.test.tsx | Created - 11 tests |

### Test Plan

- [x] npm test passes - 239/239
- [x] PostCard: all states (complete / missing image / tags / description)
- [x] PostBody: all block types (headings, code, image, links, blockquote, unknown)
- [x] TDD: 19 tests written before implementation
