### PR TITLE
feat(blog): blog listing, detail and not-found pages with tests

### DIFF
--- a/openspec/changes/core-blog-ui/tasks.md
+++ b/openspec/changes/core-blog-ui/tasks.md
@@ -17,22 +17,26 @@
 - [x] `npm test` passes (210 baseline + 10 new = 220)
 - [x] `npm run build` passes
 
-## Future Batches
+## Batch 2 — Blog Components (PR-2 of 4)
 
 ### T-02: Create blog components (PostCard + PostBody) with tests
 
-- [ ] Implement PostCard server component with conditional renders
-- [ ] Implement PostBody with Portable Text component map
-- [ ] Write unit tests for PostCard (render, missing fields, date formatting)
-- [ ] Write unit tests for PostBody (headings, code, images, links, blockquotes)
+- [x] Implement PostCard server component with conditional renders
+- [x] Implement PostBody with Portable Text component map
+- [x] Write unit tests for PostCard (render, missing fields, date formatting)
+- [x] Write unit tests for PostBody (headings, code, images, links, blockquotes)
+
+## Batch 3 — Blog Pages (PR-3 of 4)
 
 ### T-03: Create blog listing + detail pages
 
-- [ ] Implement `[locale]/blog/page.tsx` listing with ISR
-- [ ] Implement `[locale]/blog/[slug]/page.tsx` detail with generateStaticParams
-- [ ] Implement `[locale]/blog/[slug]/not-found.tsx` blog-specific 404
-- [ ] Add `generateMetadata` with SEO fields
+- [x] Implement `[locale]/blog/page.tsx` listing with ISR
+- [x] Implement `[locale]/blog/[slug]/page.tsx` detail with generateStaticParams
+- [x] Implement `[locale]/blog/[slug]/not-found.tsx` blog-specific 404
+- [x] Add `generateMetadata` with SEO fields
 - [ ] Write E2E tests for navigation flow
+
+## Batch 4 — Revalidation (PR-4 of 4)
 
 ### T-04: Create webhook revalidation endpoint
 

--- a/src/app/[locale]/blog/[slug]/__tests__/not-found.test.tsx
+++ b/src/app/[locale]/blog/[slug]/__tests__/not-found.test.tsx
@@ -1,0 +1,118 @@
+jest.mock("next-intl/server", () => ({
+  getTranslations: jest.fn(),
+}));
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { getTranslations } from "next-intl/server";
+import "@testing-library/jest-dom";
+
+function createTranslationsMock(messages: Record<string, string>) {
+  return jest.fn((key: string) => messages[key] ?? key);
+}
+
+describe("BlogNotFound", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders translated notFound title in English", async () => {
+    (getTranslations as jest.Mock).mockResolvedValue(
+      createTranslationsMock({
+        notFound: "Post not found",
+        notFoundDescription:
+          "The post you're looking for doesn't exist.",
+        backToBlog: "Back to blog",
+      })
+    );
+
+    const NotFoundModule = await import("../not-found");
+    const element = await NotFoundModule.default();
+    render(element);
+
+    expect(screen.getByText("Post not found")).toBeInTheDocument();
+  });
+
+  it("renders translated notFoundDescription", async () => {
+    (getTranslations as jest.Mock).mockResolvedValue(
+      createTranslationsMock({
+        notFound: "Post not found",
+        notFoundDescription:
+          "The post you're looking for doesn't exist.",
+        backToBlog: "Back to blog",
+      })
+    );
+
+    const NotFoundModule = await import("../not-found");
+    const element = await NotFoundModule.default();
+    render(element);
+
+    expect(
+      screen.getByText("The post you're looking for doesn't exist.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders back to blog link with correct href", async () => {
+    (getTranslations as jest.Mock).mockResolvedValue(
+      createTranslationsMock({
+        notFound: "Post not found",
+        notFoundDescription:
+          "The post you're looking for doesn't exist.",
+        backToBlog: "Back to blog",
+      })
+    );
+
+    const NotFoundModule = await import("../not-found");
+    const element = await NotFoundModule.default();
+    render(element);
+
+    const link = screen.getByRole("link", { name: "Back to blog" });
+    expect(link).toHaveAttribute("href", "/blog");
+  });
+
+  it("renders data-testid attribute", async () => {
+    (getTranslations as jest.Mock).mockResolvedValue(
+      createTranslationsMock({
+        notFound: "Post not found",
+        notFoundDescription:
+          "The post you're looking for doesn't exist.",
+        backToBlog: "Back to blog",
+      })
+    );
+
+    const NotFoundModule = await import("../not-found");
+    const element = await NotFoundModule.default();
+    render(element);
+
+    expect(screen.getByTestId("blog-not-found")).toBeInTheDocument();
+  });
+
+  it("renders Spanish translations when messages are in Spanish", async () => {
+    (getTranslations as jest.Mock).mockResolvedValue(
+      createTranslationsMock({
+        notFound: "Artículo no encontrado",
+        notFoundDescription:
+          "El artículo que buscas no existe.",
+        backToBlog: "Volver al blog",
+      })
+    );
+
+    const NotFoundModule = await import("../not-found");
+    const element = await NotFoundModule.default();
+    render(element);
+
+    expect(screen.getByText("Artículo no encontrado")).toBeInTheDocument();
+    expect(
+      screen.getByText("El artículo que buscas no existe.")
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "Volver al blog" });
+    expect(link).toHaveAttribute("href", "/blog");
+  });
+});

--- a/src/app/[locale]/blog/[slug]/__tests__/page.test.tsx
+++ b/src/app/[locale]/blog/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,158 @@
+jest.mock("@/sanity/lib/client", () => ({
+  getClient: jest.fn(),
+}));
+
+jest.mock("@/sanity/lib/queries", () => ({
+  postsByLocaleQuery: "mock-posts-by-locale-query",
+  postBySlugQuery: "mock-post-by-slug-query",
+}));
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+jest.mock("next-intl/server", () => ({
+  getLocale: jest.fn(),
+}));
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock("next/image", () => {
+  const MockImage = (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} alt={props.alt} />
+  );
+  MockImage.displayName = "MockImage";
+  return MockImage;
+});
+
+jest.mock("@/app/components/blog/PostBody", () => ({
+  PostBody: ({ body }: { body: unknown[] }) => (
+    <div data-testid="post-body">Mock PostBody: {JSON.stringify(body)}</div>
+  ),
+}));
+
+jest.mock("@/sanity/lib/image", () => ({
+  urlFor: jest.fn(() => ({
+    width: jest.fn(() => ({
+      height: jest.fn(() => ({
+        auto: jest.fn(() => ({
+          quality: jest.fn(() => ({
+            url: jest.fn(
+              () =>
+                "https://cdn.sanity.io/images/project/dataset/mock-image.jpg"
+            ),
+          })),
+        })),
+      })),
+    })),
+  })),
+}));
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { getClient } from "@/sanity/lib/client";
+import "@testing-library/jest-dom";
+
+const mockPost = {
+  _id: "1",
+  title: "Getting Started with Next.js",
+  slug: "getting-started-nextjs",
+  description:
+    "A comprehensive guide to building modern web applications with Next.js.",
+  publishedAt: "2026-05-15T10:00:00Z",
+  locale: "en",
+  tags: ["Next.js", "React", "TypeScript"],
+  coverImage: {
+    asset: {
+      url: "https://cdn.sanity.io/images/project/dataset/post1.jpg",
+    },
+  },
+  body: [
+    {
+      _type: "block",
+      style: "h2",
+      children: [{ _type: "span", text: "Introduction" }],
+    },
+  ],
+};
+
+describe("BlogDetailPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders post content for known slug", async () => {
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue(mockPost),
+    });
+
+    const PageModule = await import("../page");
+    const element = await PageModule.default({
+      params: Promise.resolve({ slug: "getting-started-nextjs", locale: "en" }),
+    });
+    render(element);
+
+    expect(screen.getByTestId("blog-detail")).toBeInTheDocument();
+    expect(screen.getByTestId("blog-detail-title")).toHaveTextContent(
+      "Getting Started with Next.js"
+    );
+    expect(screen.getByTestId("blog-detail-date")).toBeInTheDocument();
+    expect(screen.getByTestId("post-body")).toBeInTheDocument();
+  });
+
+  it("calls notFound for unknown slug", async () => {
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue(null),
+    });
+
+    const PageModule = await import("../page");
+
+    await expect(
+      PageModule.default({ params: Promise.resolve({ slug: "unknown", locale: "en" }) })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  it("renders post with tags when present", async () => {
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue(mockPost),
+    });
+
+    const PageModule = await import("../page");
+    const element = await PageModule.default({
+      params: Promise.resolve({ slug: "getting-started-nextjs", locale: "en" }),
+    });
+    render(element);
+
+    expect(screen.getByText("Next.js")).toBeInTheDocument();
+    expect(screen.getByText("React")).toBeInTheDocument();
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+  });
+
+  it("renders publishedAt date formatted in locale", async () => {
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue(mockPost),
+    });
+
+    const PageModule = await import("../page");
+    const element = await PageModule.default({
+      params: Promise.resolve({ slug: "getting-started-nextjs", locale: "en" }),
+    });
+    render(element);
+
+    const expectedDate = new Intl.DateTimeFormat("en", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }).format(new Date("2026-05-15T10:00:00Z"));
+
+    expect(screen.getByTestId("blog-detail-date")).toHaveTextContent(
+      expectedDate
+    );
+  });
+});

--- a/src/app/[locale]/blog/[slug]/not-found.tsx
+++ b/src/app/[locale]/blog/[slug]/not-found.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
+
+export default async function BlogNotFound() {
+  const t = await getTranslations("blog");
+
+  return (
+    <div
+      data-testid="blog-not-found"
+      className="container mx-auto px-4 py-16 text-center"
+    >
+      <h1 className="text-6xl font-bold text-accent mb-4">404</h1>
+      <h2 className="text-2xl font-heading font-bold mb-4">{t("notFound")}</h2>
+      <p className="text-text-main/80 mb-8">{t("notFoundDescription")}</p>
+      <Link
+        href="/blog"
+        className="inline-block rounded-lg bg-accent px-6 py-3 font-medium text-white transition-colors hover:bg-accent-hover"
+      >
+        {t("backToBlog")}
+      </Link>
+    </div>
+  );
+}

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,0 +1,135 @@
+import { notFound } from "next/navigation";
+import { getClient } from "@/sanity/lib/client";
+import {
+  postBySlugQuery,
+  postsByLocaleQuery,
+} from "@/sanity/lib/queries";
+import { PostBody } from "@/app/components/blog/PostBody";
+import { routing } from "@/i18n/routing";
+import { urlFor } from "@/sanity/lib/image";
+
+/* ── Static Generation ── */
+export async function generateStaticParams() {
+  try {
+    const locales = routing.locales;
+    const allParams = await Promise.all(
+      locales.map(async (locale: string) => {
+        const posts = await (
+          await getClient()
+        ).fetch<{ slug: string }[]>(postsByLocaleQuery, { locale });
+        return posts.map((post) => ({
+          locale,
+          slug: post.slug,
+        }));
+      })
+    );
+    return allParams.flat();
+  } catch {
+    // Gracefully degrade during build when draftMode() is unavailable.
+    return [];
+  }
+}
+
+/* ── Metadata ── */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>;
+}) {
+  const { slug, locale } = await params;
+  const post = await (
+    await getClient()
+  ).fetch<{
+    title: string;
+    description?: string | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coverImage?: any;
+  } | null>(postBySlugQuery, { slug, locale });
+
+  if (!post) return {};
+
+  const ogImage = post.coverImage?.asset?._ref
+    ? [{ url: urlFor(post.coverImage).width(1200).url() }]
+    : [];
+
+  return {
+    title: post.title,
+    description: post.description ?? undefined,
+    openGraph: {
+      title: post.title,
+      description: post.description ?? undefined,
+      images: ogImage,
+    },
+  };
+}
+
+/* ── Cache ── */
+export const revalidate = 60;
+
+/* ── Page ── */
+export default async function BlogDetailPage({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>;
+}) {
+  const { slug, locale } = await params;
+  const post = await (
+    await getClient()
+  ).fetch<{
+    title: string;
+    description?: string | null;
+    publishedAt?: string | null;
+    locale: string;
+    tags?: string[] | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coverImage?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any[];
+  } | null>(postBySlugQuery, { slug, locale });
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <article
+      data-testid="blog-detail"
+      className="container mx-auto px-4 py-8 max-w-3xl"
+    >
+      <h1
+        data-testid="blog-detail-title"
+        className="text-4xl font-heading font-bold mb-4"
+      >
+        {post.title}
+      </h1>
+
+      {post.publishedAt && (
+        <p
+          data-testid="blog-detail-date"
+          className="text-sm font-body text-text-main/60 mb-6"
+        >
+          {new Intl.DateTimeFormat(locale, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          }).format(new Date(post.publishedAt))}
+        </p>
+      )}
+
+      {post.tags && post.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-6">
+          {post.tags.map((tag: string) => (
+            <span
+              key={tag}
+              className="px-3 py-1 bg-background-main border border-accent/30 text-text-main text-xs font-body font-medium rounded-full"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <PostBody body={post.body} />
+    </article>
+  );
+}

--- a/src/app/[locale]/blog/__tests__/page.test.tsx
+++ b/src/app/[locale]/blog/__tests__/page.test.tsx
@@ -1,0 +1,145 @@
+jest.mock("@/sanity/lib/client", () => ({
+  getClient: jest.fn(),
+}));
+
+jest.mock("next-intl/server", () => ({
+  getLocale: jest.fn(),
+  getTranslations: jest.fn(),
+}));
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock("next/image", () => {
+  const MockImage = (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <img {...props} alt={props.alt} />
+  );
+  MockImage.displayName = "MockImage";
+  return MockImage;
+});
+
+jest.mock("@/sanity/lib/queries", () => ({
+  postsByLocaleQuery: "mock-posts-by-locale-query",
+}));
+
+jest.mock("@/sanity/lib/image", () => ({
+  urlFor: jest.fn(() => ({
+    width: jest.fn(() => ({
+      height: jest.fn(() => ({
+        auto: jest.fn(() => ({
+          quality: jest.fn(() => ({
+            url: jest.fn(
+              () =>
+                "https://cdn.sanity.io/images/project/dataset/mock-image.jpg"
+            ),
+          })),
+        })),
+      })),
+    })),
+  })),
+}));
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { getClient } from "@/sanity/lib/client";
+import { getLocale, getTranslations } from "next-intl/server";
+import "@testing-library/jest-dom";
+
+const mockPosts = [
+  {
+    _id: "1",
+    title: "Getting Started with Next.js",
+    slug: "getting-started-nextjs",
+    description: "A comprehensive guide.",
+    publishedAt: "2026-05-15T10:00:00Z",
+    tags: ["Next.js", "React"],
+    coverImage: {
+      asset: { url: "https://cdn.sanity.io/images/project/dataset/post1.jpg" },
+    },
+  },
+  {
+    _id: "2",
+    title: "TypeScript Tips",
+    slug: "typescript-tips",
+    description: null,
+    publishedAt: null,
+    tags: null,
+    coverImage: null,
+  },
+];
+
+const mockTranslations = jest.fn((key: string) => {
+  const messages: Record<string, string> = {
+    title: "Blog",
+    emptyState: "No posts yet. Check back soon!",
+  };
+  return messages[key] ?? key;
+});
+
+describe("BlogListingPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getTranslations as jest.Mock).mockResolvedValue(mockTranslations);
+  });
+
+  it("renders PostCards grid when posts exist", async () => {
+    (getLocale as jest.Mock).mockResolvedValue("en");
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue(mockPosts),
+    });
+
+    const PageModule = await import("../page");
+    const element = await PageModule.default();
+    render(element);
+
+    expect(screen.getByTestId("blog-listing")).toBeInTheDocument();
+    expect(screen.getAllByTestId("post-card")).toHaveLength(2);
+  });
+
+  it("renders empty state when no posts", async () => {
+    (getLocale as jest.Mock).mockResolvedValue("en");
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue([]),
+    });
+
+    const PageModule = await import("../page");
+    const element = await PageModule.default();
+    render(element);
+
+    expect(screen.getByTestId("blog-empty-state")).toBeInTheDocument();
+    expect(
+      screen.getByText("No posts yet. Check back soon!")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("blog-listing")).not.toBeInTheDocument();
+  });
+
+  it("renders correct number of PostCards for multiple posts", async () => {
+    const threePosts = [
+      ...mockPosts,
+      {
+        _id: "3",
+        title: "CSS Grid Layout",
+        slug: "css-grid-layout",
+        description: "Master CSS Grid.",
+        publishedAt: "2026-06-01T00:00:00Z",
+        tags: ["CSS"],
+        coverImage: null,
+      },
+    ];
+
+    (getLocale as jest.Mock).mockResolvedValue("en");
+    (getClient as jest.Mock).mockResolvedValue({
+      fetch: jest.fn().mockResolvedValue(threePosts),
+    });
+
+    const PageModule = await import("../page");
+    const element = await PageModule.default();
+    render(element);
+
+    expect(screen.getByTestId("blog-listing")).toBeInTheDocument();
+    expect(screen.getAllByTestId("post-card")).toHaveLength(3);
+  });
+});

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,0 +1,61 @@
+import { getLocale, getTranslations } from "next-intl/server";
+import { getClient } from "@/sanity/lib/client";
+import { postsByLocaleQuery } from "@/sanity/lib/queries";
+import { PostCard } from "@/app/components/blog/PostCard";
+
+export const revalidate = 60;
+
+export async function generateMetadata() {
+  return {
+    title: "Blog | Carlos Correa",
+  };
+}
+
+export default async function BlogListingPage() {
+  const locale = await getLocale();
+  const t = await getTranslations("blog");
+  const posts = await (await getClient()).fetch(postsByLocaleQuery, { locale });
+
+  if (posts.length === 0) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-heading font-bold mb-8">{t("title")}</h1>
+        <p data-testid="blog-empty-state">{t("emptyState")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-heading font-bold mb-8">{t("title")}</h1>
+      <div
+        data-testid="blog-listing"
+        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+      >
+        {posts.map(
+          (post: {
+            _id: string;
+            title: string;
+            slug: string;
+            description?: string | null;
+            publishedAt?: string | null;
+            tags?: string[] | null;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            coverImage?: any;
+          }) => (
+            <PostCard
+              key={post.slug}
+              title={post.title}
+              slug={post.slug}
+              description={post.description}
+              publishedAt={post.publishedAt}
+              tags={post.tags}
+              coverImage={post.coverImage}
+              locale={locale}
+            />
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -13,7 +13,7 @@ export const postsByLocaleQuery = defineQuery(`
     description,
     publishedAt,
     tags,
-    "coverImage": coverImage.asset->url
+    "coverImage": coverImage{asset, alt}
   }
 `)
 
@@ -31,7 +31,7 @@ export const postBySlugQuery = defineQuery(`
     publishedAt,
     locale,
     tags,
-    "coverImage": coverImage.asset->url,
+    "coverImage": coverImage{asset, alt},
     body
   }
 `)


### PR DESCRIPTION
## Summary

Blog listing, detail and not-found pages with tests. PR-3 de 4 para core-blog-ui (stacked-to-main). Sobre PR-2 (#91 mergeado).

### Changes

| File | Change |
|------|--------|
| src/app/[locale]/blog/page.tsx | Created - Listing with PostCard grid, empty state, ISR |
| src/app/[locale]/blog/[slug]/page.tsx | Created - Detail with generateStaticParams, generateMetadata, PostBody |
| src/app/[locale]/blog/[slug]/not-found.tsx | Created - 404 con i18n translations |
| src/app/[locale]/blog/__tests__/page.test.tsx | Created - Listing tests |
| src/app/[locale]/blog/[slug]/__tests__/page.test.tsx | Created - Detail tests |
| src/app/[locale]/blog/[slug]/__tests__/not-found.test.tsx | Created - not-found tests |
| src/sanity/lib/queries.ts | Modified - coverImage projection fix |

### Test Plan

- [x] npm run build passes
- [x] npm test passes - 251/251 (baseline + 12 new)
- [x] Listing renders PostCard grid
- [x] Detail renders PostBody for known slug
- [x] Detail calls notFound() for unknown slug
- [x] not-found shows translated messages
- [x] TDD: 12 tests written before implementation
