### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete regular expression for hostnames

### DIFF
--- a/src/app/components/contact/ContactInformation.test.tsx
+++ b/src/app/components/contact/ContactInformation.test.tsx
@@ -42,7 +42,7 @@ describe("ContactInformation", () => {
     expect(screen.getByText("Teléfono")).toBeInTheDocument();
     expect(screen.getByText(/\+584248599166/i)).toBeInTheDocument();
     expect(screen.getByText("Portfolio")).toBeInTheDocument();
-    expect(screen.getByText(/www.carlos-correa.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/www\.carlos-correa\.com/i)).toBeInTheDocument();
     expect(screen.getAllByText("Disponible para proyectos freelance").length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Deadflight/portfolio-next/security/code-scanning/10](https://github.com/Deadflight/portfolio-next/security/code-scanning/10)

Use an exact/literal hostname regex in the test by escaping `.` characters (and optionally anchoring if desired).  
Best minimal fix without changing functionality: in `src/app/components/contact/ContactInformation.test.tsx`, update line 45 from `/www.carlos-correa.com/i` to `/www\.carlos-correa\.com/i`. This keeps case-insensitive matching and current test behavior while removing unintended wildcard matching.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
